### PR TITLE
Include build_index in ClusterConfig json dump

### DIFF
--- a/cluster_config.py
+++ b/cluster_config.py
@@ -62,6 +62,7 @@ class ClusterConfig:
                 'port': self.port,
                 'name': self.name,
                 'version': self.version,
+                'build_index': self.build_index,
                 'certificate': self.certificate,
                 'private_key': self.private_key}
 


### PR DESCRIPTION
**Issue**
When the clusters.json file is dumped, it is missing the value for build_index. This is due to the save() function not dumping the value within cluster_config.py:
```
    def save(self):
        return {'hostname': self.hostname,
                'port': self.port,
                'name': self.name,
                'version': self.version,
                'certificate': self.certificate,
                'private_key': self.private_key}
```
**User impact**
If a user encounters an error during the execution of bright_cluster, the user might need to delete the clusters.json file. Otherwise, as the value of build_index is missing from the file, it will be left to None, and cause misbehaviors in the script such as a wrong value returned by cluster_pythoncm_directory().
